### PR TITLE
Add Dockerfile and instructions

### DIFF
--- a/DockerBotConfig
+++ b/DockerBotConfig
@@ -1,0 +1,9 @@
+DISCORD_BOT_TOKEN= #Bot token from the Discord developer portal
+DISCORD_BOT_LANGUAGE= # Bot language (key from translations.json), E.g. "en"
+
+G5API_URL= # URL where the web panel is hosted
+
+POSTGRESQL_USER= # "PUGs" (if you used the same username)
+POSTGRESQL_PASSWORD= # The DB password you set
+POSTGRESQL_DB= # "PUGs" (if you used the same DB name)
+POSTGRESQL_HOST= # The IP address of the postgres server (get this with "ipconfig" on Windows or "ip addr" on linux)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.6-slim
 
 # install required packages
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:slim
+
+# install required packages
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+	libpq-dev \
+	postgresql-client \
+	gcc
+
+# create folder for application, copy application, and set directory at application
+RUN mkdir /PugBot
+COPY / /PugBot/
+WORKDIR /PugBot/
+
+# install python packages 
+RUN pip3 install -r requirements.txt
+
+# copy .env file
+COPY /DockerBotConfig /PugBot/.env
+
+# apply yoyo migrations and launch application
+CMD python3 migrate.py up && python3 launcher.py

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ A Discord bot to manage CS:GO PUGs. Connects to [G5API](https://github.com/Phlex
 5. Run the psql tool with `sudo -u postgres psql` and create a database by running the following commands:
 
     ```sql
-    CREATE ROLE PUGs WITH LOGIN PASSWORD 'yourpassword';
-    CREATE DATABASE PUGs OWNER PUGs;
+    CREATE ROLE "PUGs" WITH LOGIN PASSWORD 'yourpassword';
+    CREATE DATABASE "PUGs" OWNER PUGs;
     ```
 
     Be sure to replace `'yourpassword'` with your own desired password.
@@ -51,6 +51,44 @@ A Discord bot to manage CS:GO PUGs. Connects to [G5API](https://github.com/Phlex
 7. Apply the database migrations by running `python3 migrate.py up`.
 
 8. Run the launcher Python script by running, `python3 launcher.py`.
+
+### Docker Setup:
+1.  First you must have a bot instance to run this script on. Follow Discord's tutorial [here](https://discord.onl/2019/03/21/how-to-set-up-a-bot-application/) on how to set one up.
+
+    * The required permissions is `administrator`.
+    * Enable the "server members intent" for your bot, as shown [here](https://discordpy.readthedocs.io/en/latest/intents.html#privileged-intents)
+
+2. Set up your PostgreSQL database
+  * This can be set up in a docker container, see [Postgres](https://hub.docker.com/_/postgres). For example:
+    * ```
+		docker pull postgres:latest
+		docker run --name postgres -e POSTGRES_USER="PUGs" -e POSTGRES_PASSWORD="yourpassword" -e POSTGRES_DB="PUGs" -p 5432:5432 -d postgres:latest
+   * If you are using an already existing PostgreSQL, run the following commands using psql:
+	   * ```sql
+		 CREATE ROLE "PUGs" WITH LOGIN PASSWORD 'yourpassword';
+		 CREATE DATABASE "PUGs" OWNER "PUGs";
+ * Be sure to replace `'yourpassword'` with your own desired password.
+
+3. Edit ```DockerBotConfig```. Fill this template in with the requisite information you've gathered...
+
+    ```py
+    DISCORD_BOT_TOKEN= #Bot token from the Discord developer portal
+    DISCORD_BOT_LANGUAGE= # Bot language (key from translations.json), E.g. "en"
+
+    G5API_URL= # URL where the web panel is hosted
+
+    POSTGRESQL_USER= # "PUGs" (if you used the same username)
+    POSTGRESQL_PASSWORD= # The DB password you set
+    POSTGRESQL_DB= # "PUGs" (if you used the same DB name)
+    POSTGRESQL_HOST= # The IP address of the postgres server (get this with "ipconfig" on Windows or "ip addr" on linux)
+    ```
+
+4. Build the docker container using ```Dockerfile```.
+
+   * ```docker build -t yourname/csgo-pugs-bot:latest .```
+
+5. Start up the container
+   * ```docker container run --name csgo-pugs-bot yourname/csgo-pugs-bot:latest```
 
 ## Contributions
 


### PR DESCRIPTION
Add Dockerfile
Add DockerBotConfig (.env file used in docker container)
Change README.md to include docker instructions and fix psql command (adding "" for role, needed on some systems)

Dockerfile based on python:slim for smaller file sizes. It will install all python3 and pip3 requirements, and all requirements listed in requirements.txt. It then runs migrate.py up and finally launches the application with launcher.py
Note: Container does not include PostgreSQL. This must be run separately, such as in another container.

Added instructions for setting up the container using the dockerfile, as well as changed psql to include "" around the role which is required for some systems.