### PR TITLE
Update minimum requirements for aiohttp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 discord.py>=1.5.1
 python-Levenshtein-wheels>=0.13.1
-aiohttp>=3.6.2
+aiohttp>=3.7.4
 asyncpg>=0.20.1
 python-dotenv>=0.13.0
 yoyo-migrations>=7.0.2


### PR DESCRIPTION
Update the minimum requirements for aiohttp to resolve CVE-2021-21330 affecting all builds below 3.7.4